### PR TITLE
Adding server.js to allow node serve built files

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/jbasdf/react-kindling-client"
   },
   "scripts": {
+    "start": "node server/index.js",
     "test": "karma start",
     "coveralls": "cat coverage/lcov.info | coveralls",
     "build": "webpack --config webpack.release.js --progress --profile --colors",
@@ -18,6 +19,7 @@
   "dependencies": {
     "babel": "^5.3.3",
     "babel-runtime": "^5.3.3",
+    "express": "^4.12.3",
     "flux": "^2.0.3",
     "lodash": "^3.8.0",
     "material-ui": "^0.8.0",

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,3 @@
+require('babel/register');
+
+module.exports = require('./server');

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,23 @@
+"use strict";
+
+import path             from 'path';
+import Express          from 'express';
+
+var app = Express();
+var server;
+
+//const PATH_STYLES = path.resolve(__dirname, '../app/styles');
+const PATH_DIST = path.resolve(__dirname, '../build');
+
+//app.use('/styles', Express.static(PATH_STYLES));
+app.use(Express.static(PATH_DIST));
+
+app.get('/', (req, res) => {
+  res.sendFile(path.resolve(__dirname, '../app/index.html'));
+});
+
+server = app.listen(process.env.PORT || 3000, () => {
+  var port = server.address().port;
+
+  console.log('Server is listening at %s', port);
+});


### PR DESCRIPTION
Its working as long as I change the index.html to reflect exactly the same name of the bundle.js that was produced with "npm run build". Maybe the build should generate a static filename like "bundle.js" .
